### PR TITLE
Add Editable Code Interface

### DIFF
--- a/src/js/editable_code.ts
+++ b/src/js/editable_code.ts
@@ -1,0 +1,113 @@
+import * as monaco from 'monaco-editor';
+import * as ts from 'typescript';
+
+export interface EditableCode {
+    readonly containerID: string;
+    readonly executeFunction: Function;
+    editor: monaco.editor.IStandaloneCodeEditor;
+    // The init function must be called after constructing the element.
+    // It needs to have the @initEditable decorator.
+    // This creates the editor and replaces the function.
+    init(): any;
+    // non editable code that is placed before the editable code
+    // Example: predefine variables.
+    preEditable(): any;
+    // non editable code that is placed after the editable code
+    // Example: return values.
+    postEditable(...args: any[]): any;
+    editable(): any;
+}
+
+export function initEditable(containerID: string, executeFunction: Function) {
+    return function (targetObject: EditableCode, propertyKey: string, descriptor: PropertyDescriptor) {
+        // construct the editor.
+        if (targetObject.editor == null) {
+            const functionString = targetObject.editable.toString();
+            const functionContentString = calculateFunctionContentSubstring(functionString);
+            const editor = createEditor(containerID, functionContentString);
+            targetObject.editable = () => constructNewEditableFunction(functionContentString, targetObject)();
+            targetObject.editor = editor;
+            editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+                editor.trigger(`anyString`, 'editor.action.formatDocument', undefined);
+                const editorContent = editor.getValue();
+                const transpile = ts.transpileModule(editorContent, transpileOptions);
+                if (transpile.diagnostics !== undefined && transpile.diagnostics.length > 0) {
+                    console.error(
+                        `Compilation of the function failed: ${transpile.diagnostics.toString()} \nContent: ${editorContent}`
+                    );
+                } else {
+                    // Replace the new function with the existing one.
+                    targetObject.editable = () => constructNewEditableFunction(functionContentString, targetObject)();
+                    executeFunction();
+                }
+            });
+        }
+    };
+}
+
+function constructNewEditableFunction(editableFunctionContentString: string, targetObject: EditableCode): Function {
+    const strictDefinition = '"use strict"';
+    const borderString = ';\n';
+    const preFunctionContentString = calculateFunctionContentSubstring(targetObject.preEditable.toString());
+    const postFunctionContentString = calculateFunctionContentSubstring(targetObject.postEditable.toString());
+    const newFunction = new Function(
+        strictDefinition +
+            borderString +
+            preFunctionContentString +
+            borderString +
+            editableFunctionContentString +
+            borderString +
+            postFunctionContentString
+    );
+    // The new Function is similar to eval() but les dangerous.
+    // call lets us change the context to the target object.
+    // Thus this points to the correct object.
+    // Wrap it into a try catch block to prevent forwarding errors.
+    return () => {
+        try {
+            return newFunction.call(targetObject);
+        } catch (e) {
+            console.error(e);
+        }
+    };
+}
+
+function calculateFunctionContentSubstring(functionString: string): string {
+    const functionOpeningParenthesisIndex = functionString.indexOf('{');
+    const functionClosingParenthesisIndex = functionString.lastIndexOf('}');
+    return functionString.substring(functionOpeningParenthesisIndex + 1, functionClosingParenthesisIndex - 1).trim();
+}
+
+function createEditor(containerID: string, content: string): monaco.editor.IStandaloneCodeEditor {
+    const container = document.getElementById(containerID);
+    if (container === null) {
+        throw new ReferenceError(
+            `Expected to find container element for the editor (empty div element) with the id ${containerID}. No Editor has been created.`
+        );
+    }
+    const editor = monaco.editor.create(container, {
+        value: content,
+        language: 'typescript',
+        theme: 'vs-dark',
+        automaticLayout: true,
+        autoIndent: 'full',
+        contextmenu: false,
+        formatOnType: true,
+        // readOnly: true,
+    });
+    editor.onDidScrollChange(() => editor.trigger(`anyString`, 'editor.action.formatDocument', undefined));
+    return editor;
+}
+
+const transpileOptions = {
+    reportDiagnostics: true,
+    compilerOptions: {
+        noEmitOnError: true,
+        noImplicitAny: true,
+        strick: true,
+        strictNullChecks: true,
+        allowSyntheticDefaultImports: true,
+        preserveConstEnums: true,
+        target: ts.ScriptTarget.ES2020,
+    },
+};

--- a/src/js/lecture_1.ts
+++ b/src/js/lecture_1.ts
@@ -1,76 +1,33 @@
-import * as monaco from 'monaco-editor';
-import * as ts from 'typescript';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '../css/main.scss';
+import * as monaco from 'monaco-editor';
+import { EditableCode, initEditable } from './editable_code';
 
-const scriptId = 'scriptID';
-
-/**
- * 1. work with typescript as files without raw loader
- * 2. always have a method that re renders everything
- * 3. call it on page load.
- * 4. use decorators over the methods.
- * 5. in the first evaluation: construct a new editor for the decorated method. use function.toString in order to get the source code.
- * 6. link the editor ctrl enter to first do step 7. and the re render everything.
- * 7. take the value of the editor, wrap it into the function name and attach it to a separate script which is updated every time.
- */
-
-const editor = monaco.editor.create(document.getElementById('container')!, {
-    value: [
-        '// Press ctrl + enter to execute the code in this editor',
-        'function x() {',
-        '\tconst str: string = "Hello World";',
-        '\tconst test: Number = str;',
-        '\tconsole.log(str);',
-        '}'
-    ].join('\n'),
-    language: 'typescript',
-    theme: 'vs-dark'
-});
-
-// Taken from: https://stackoverflow.com/questions/939326/execute-javascript-code-stored-as-a-string
-function executeScript (source: string, scriptID: string) {
-    // remove the old script if it exists
-    const oldScript = document.getElementById(scriptID);
-    if (oldScript) {
-        oldScript.remove();
-    }
-    const newScript = document.createElement('script');
-    newScript.setAttribute('id', scriptID);
-    newScript.onload = newScript.onerror = function () {
-        this.remove();
-    };
-    newScript.src = 'data:text/plain;base64,' + btoa(source);
-    document.body.appendChild(newScript);
+function execute() {
+    console.log(temp.editable());
 }
 
-const transpileOptions = {
-    reportDiagnostics: true,
-    compilerOptions: {
-        noEmitOnError: true,
-        noImplicitAny: true,
-        strick: true,
-        typeCheck: true,
-        strictNullChecks: true,
-        allowSyntheticDefaultImports: true,
-        preserveConstEnums: true,
-        alwaysStrict: true,
-        target: ts.ScriptTarget.ES2020
+class EditorTry implements EditableCode {
+    readonly containerID: string = 'container';
+    readonly executeFunction: Function = execute;
+    editor: monaco.editor.IStandaloneCodeEditor;
+    preEditable() {}
+    postEditable(str: string) {
+        return str;
     }
-};
 
-// Hook for doing stuff on content change (code edit).
-editor.onDidChangeModelContent(eve => {
-    console.log(eve);
-});
-
-const executionCommand = editor.addCommand(
-    monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
-    function () {
-        const editorContent = editor.getValue();
-        const transpile = ts.transpileModule(editorContent, transpileOptions);
-        console.log(transpile);
-        executeScript(transpile.outputText, scriptId);
+    @initEditable('container', execute)
+    init() {
+        return this;
     }
-);
-console.log(executionCommand);
+
+    editable() {
+        const str = 'Hello World';
+        console.log(str);
+        console.log(this.editor);
+    }
+}
+
+const temp = new EditorTry();
+temp.init();
+execute();


### PR DESCRIPTION
This PR adds an interface that makes it easy to add editable code to the website. It is implemented with a typescript interface `EditableCode` and a decorator `@initEditable('HTMLElementID', renderFunction)`. It is possible to write code before the displayed code and code that is placed after the code is executed. Especially the code that can be placed after the editable code is important since it can be used to return variables that are defined in the editable code. An example is shown below.

When we decide to take an abstract class instead of an interface, the necessary code the `init` function which needs to be called after the constructor, could be avoided.

The interface:

```
interface EditableCode {
    readonly containerID: string;
    readonly executeFunction: Function;
    editor: monaco.editor.IStandaloneCodeEditor;
    // The init function must be called after constructing the element.
    // It needs to have the @initEditable decorator.
    // This creates the editor and replaces the function.
    init(): any;
    // non editable code that is placed before the editable code
    // Example: predefine variables.
    preEditable(): any;
    // non editable code that is placed after the editable code
    // Example: return values.
    postEditable(...args: any[]): any;
    editable(): any;
}
```

Minimal Example with returned value.

```
// The render loop.
function execute() {
    console.log(temp.editable());
}

// The class that contains one editable code segment.
class EditorTry implements EditableCode {
    editor: monaco.editor.IStandaloneCodeEditor;
    preEditable() {}
    postEditable(str: string) {
        return str;
    }

    @initEditable('container', execute)
    init() {
        return this;
    }

    editable() {
        const str = 'Hello World';
        console.log(str);
        console.log(this.editor);
    }
}

const temp = new EditorTry().init();
execute();
```
Absolute Minimal Example:

```
// The class that contains one editable code segment.
class EditorTry implements EditableCode {
    editor: monaco.editor.IStandaloneCodeEditor;
    preEditable() {}
    postEditable() {}

    @initEditable('container', execute)
    init() {
        // enable chaining with constructor.
        return this;
    }

    editable() {
        console.log(this.editor);
    }
}

const temp = new EditorTry().init();
execute();
```